### PR TITLE
Fixed jQuery error on front end and disabled opening from browserSync

### DIFF
--- a/{{cookiecutter.repo_name}}/gulpfile.js
+++ b/{{cookiecutter.repo_name}}/gulpfile.js
@@ -86,7 +86,8 @@ gulp.task('extras', () => {
 gulp.task('watch', ['sass', 'extras', 'watchify'], () => {
   browserSync.init({
     server: 'public',
-    files: 'public/**/*'
+    files: 'public/**/*',
+    open: false
   });
 
   gulp.watch('src/scss/**/*.scss', ['sass']);

--- a/{{cookiecutter.repo_name}}/src/js/app.js
+++ b/{{cookiecutter.repo_name}}/src/js/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import $ from 'jQuery'
+import $ from 'jquery'
 import 'foundation-sites'
 
 $(document).foundation()


### PR DESCRIPTION
- `$(document).foundation()` was throwing an error on the front end; fixed that
- Also disabled auto opening of a browser window with the wrong port.
